### PR TITLE
support multiple sites

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -1,7 +1,6 @@
 package omada
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -16,7 +15,6 @@ func makeDNSSafe(input string) string {
 
 	// Convert the string to lower case
 	input = strings.ToLower(input)
-	input = fmt.Sprintf("%s", input)
 
 	return input
 }

--- a/example/main.go
+++ b/example/main.go
@@ -33,7 +33,12 @@ func main() {
 	}
 
 	// login
-	err = omada.Login(user, pass, siteName)
+	err = omada.Login(user, pass)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// set site
+	err = omada.SetSite(siteName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/login.go
+++ b/login.go
@@ -18,6 +18,7 @@ type Controller struct {
 	controllerId string
 	token        string
 	siteId       string
+	sites        map[string]string
 }
 
 type ControllerInfo struct {
@@ -127,7 +128,7 @@ func (c *Controller) GetControllerInfo() error {
 
 }
 
-func (c *Controller) Login(user string, pass string, siteName string) error {
+func (c *Controller) Login(user string, pass string) error {
 
 	endpoint := c.baseURL + "/" + c.controllerId + "/api/v2/login"
 
@@ -169,7 +170,7 @@ func (c *Controller) Login(user string, pass string, siteName string) error {
 	token := login.Result.Token
 	c.token = token
 
-	err = c.getSiteId(siteName)
+	err = c.getSites()
 	if err != nil {
 		return err
 	}
@@ -178,7 +179,7 @@ func (c *Controller) Login(user string, pass string, siteName string) error {
 
 }
 
-func (c *Controller) getSiteId(site string) error {
+func (c *Controller) getSites() error {
 
 	path := "api/v2/users/current"
 	url := fmt.Sprintf("%s/%s/%s", c.baseURL, c.controllerId, path)
@@ -205,17 +206,11 @@ func (c *Controller) getSiteId(site string) error {
 		return err
 	}
 
-	var siteId string
+	c.sites = make(map[string]string)
 	for _, v := range currentUserResponse.Result.Privilege.Sites {
-		if v.Name == site {
-			siteId = v.Key
-		}
+		c.sites[v.Name] = v.Key
+		c.SetSite(v.Name)
 	}
-
-	if siteId == "" {
-		return fmt.Errorf("site not found: %s", site)
-	}
-	c.siteId = siteId
 
 	return nil
 

--- a/login.go
+++ b/login.go
@@ -18,7 +18,7 @@ type Controller struct {
 	controllerId string
 	token        string
 	siteId       string
-	sites        map[string]string
+	Sites        map[string]string
 }
 
 type ControllerInfo struct {
@@ -170,7 +170,7 @@ func (c *Controller) Login(user string, pass string) error {
 	token := login.Result.Token
 	c.token = token
 
-	err = c.GetSites()
+	err = c.getSites()
 	if err != nil {
 		return err
 	}

--- a/login.go
+++ b/login.go
@@ -18,7 +18,7 @@ type Controller struct {
 	controllerId string
 	token        string
 	siteId       string
-	Sites        map[string]string
+	sites        map[string]string
 }
 
 type ControllerInfo struct {
@@ -170,46 +170,9 @@ func (c *Controller) Login(user string, pass string) error {
 	token := login.Result.Token
 	c.token = token
 
-	err = c.getSites()
+	err = c.GetSites()
 	if err != nil {
 		return err
-	}
-
-	return nil
-
-}
-
-func (c *Controller) getSites() error {
-
-	path := "api/v2/users/current"
-	url := fmt.Sprintf("%s/%s/%s", c.baseURL, c.controllerId, path)
-
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Add("Csrf-Token", c.token)
-
-	res, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		err = fmt.Errorf("status code: %d", res.StatusCode)
-		return err
-	}
-
-	var currentUserResponse currentUserResponse
-	if err := json.NewDecoder(res.Body).Decode(&currentUserResponse); err != nil {
-		return err
-	}
-
-	c.sites = make(map[string]string)
-	for _, v := range currentUserResponse.Result.Privilege.Sites {
-		c.sites[v.Name] = v.Key
-		c.SetSite(v.Name)
 	}
 
 	return nil

--- a/login.go
+++ b/login.go
@@ -18,7 +18,7 @@ type Controller struct {
 	controllerId string
 	token        string
 	siteId       string
-	sites        map[string]string
+	Sites        map[string]string
 }
 
 type ControllerInfo struct {

--- a/site.go
+++ b/site.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func (c *Controller) GetSites() error {
+func (c *Controller) getSites() error {
 
 	path := "api/v2/users/current"
 	url := fmt.Sprintf("%s/%s/%s", c.baseURL, c.controllerId, path)

--- a/site.go
+++ b/site.go
@@ -1,0 +1,12 @@
+package omada
+
+import "fmt"
+
+func (c *Controller) SetSite(site string) error {
+	siteId, ok := c.sites[site]
+	if !ok {
+		return fmt.Errorf("site not found: %s", site)
+	}
+	c.siteId = siteId
+	return nil
+}

--- a/site.go
+++ b/site.go
@@ -1,6 +1,47 @@
 package omada
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func (c *Controller) GetSites() error {
+
+	path := "api/v2/users/current"
+	url := fmt.Sprintf("%s/%s/%s", c.baseURL, c.controllerId, path)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Add("Csrf-Token", c.token)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		err = fmt.Errorf("status code: %d", res.StatusCode)
+		return err
+	}
+
+	var currentUserResponse currentUserResponse
+	if err := json.NewDecoder(res.Body).Decode(&currentUserResponse); err != nil {
+		return err
+	}
+
+	c.sites = make(map[string]string)
+	for _, v := range currentUserResponse.Result.Privilege.Sites {
+		c.sites[v.Name] = v.Key
+		c.SetSite(v.Name)
+	}
+
+	return nil
+
+}
 
 func (c *Controller) SetSite(site string) error {
 	siteId, ok := c.sites[site]

--- a/site.go
+++ b/site.go
@@ -33,9 +33,9 @@ func (c *Controller) getSites() error {
 		return err
 	}
 
-	c.sites = make(map[string]string)
+	c.Sites = make(map[string]string)
 	for _, v := range currentUserResponse.Result.Privilege.Sites {
-		c.sites[v.Name] = v.Key
+		c.Sites[v.Name] = v.Key
 		c.SetSite(v.Name)
 	}
 
@@ -44,7 +44,7 @@ func (c *Controller) getSites() error {
 }
 
 func (c *Controller) SetSite(site string) error {
-	siteId, ok := c.sites[site]
+	siteId, ok := c.Sites[site]
 	if !ok {
 		return fmt.Errorf("site not found: %s", site)
 	}


### PR DESCRIPTION
- Support multiple sites by adding a `SetSite(<sitename>)` function to switch between different sites
- see example implementation at `example/main.go`
- Sites are discovered based on user permissions, and one site will be set automatically at login