### PR TITLE
Add more client properties

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,6 +23,47 @@ type Client struct {
 	Ip       string `json:"ip"`
 	MAC      string `json:"mac"`
 	DnsName  string
+
+	Active                    bool     `json:"active"`
+	Activity                  int64    `json:"activity"`
+	APMac                     string   `json:"apMac,omitempty"`
+	APName                    string   `json:"apName,omitempty"`
+	AuthStatus                int      `json:"authStatus"`
+	Channel                   int      `json:"channel,omitempty"`
+	ConnectDevType            string   `json:"connectDevType,omitempty"`
+	ConnectedToWirelessRouter bool     `json:"connectedToWirelessRouter"`
+	ConnectType               int      `json:"connectType,omitempty"`
+	DeviceType                string   `json:"deviceType,omitempty"`
+	Dot1xVlan                 int      `json:"dot1xVlan"`
+	DownPacket                int64    `json:"downPacket"`
+	Guest                     bool     `json:"guest"`
+	HealthScore               int      `json:"healthScore"`
+	IPV6List                  []string `json:"ipv6List"`
+	LastSeen                  int64    `json:"lastSeen"`
+	Manager                   bool     `json:"manager"`
+	NetworkName               string   `json:"networkName,omitempty"`
+	Port                      int      `json:"port"`
+	PowerSave                 bool     `json:"powerSave"`
+	RadioID                   int      `json:"radioId,omitempty"`
+	RSSI                      int      `json:"rssi"`
+	RXRate                    int64    `json:"rxRate,omitempty"`
+	SignalLevel               int      `json:"signalLevel"`
+	SignalRank                int      `json:"signalRank"`
+	SNR                       int      `json:"snr"`
+	SSID                      string   `json:"ssid,omitempty"`
+	StackableSwitch           bool     `json:"stackableSwitch"`
+	StandardPort              string   `json:"standardPort,omitempty"`
+	Support5G2                bool     `json:"support5g2"`
+	SwitchMac                 string   `json:"switchMac,omitempty"`
+	SwitchName                string   `json:"switchName,omitempty"`
+	TrafficDown               int64    `json:"trafficDown"`
+	TrafficUp                 int64    `json:"trafficUp"`
+	TXRate                    int64    `json:"txRate,omitempty"`
+	UpPacket                  int64    `json:"upPacket"`
+	Uptime                    int64    `json:"uptime"`
+	VID                       int      `json:"vid"`
+	WifiMode                  int      `json:"wifiMode,omitempty"`
+	Wireless                  bool     `json:"wireless"`
 }
 
 func (c *Controller) GetClients() ([]Client, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -17,11 +17,17 @@ func TestGetClients(t *testing.T) {
 	expectedClients := 3
 	assert.Equal(t, testController.siteId, "Default")
 	assert.Len(t, clients, expectedClients)
-	assert.Equal(t, "Client 001", clients[0].Name)
-	assert.Equal(t, "Google Nest Mini", clients[1].Name)
-	assert.Equal(t, "client-001", clients[0].DnsName)
-	assert.Equal(t, "google-nest-mini", clients[1].DnsName)
 
+	assert.Equal(t, "Client 001", clients[0].Name)
+	assert.Equal(t, "client-001", clients[0].DnsName)
 	ip := net.ParseIP(clients[0].Ip) // ParseIP returns nil rather than error if unable to parse
 	assert.NotNil(t, ip)
+
+	assert.Equal(t, "Google Nest Mini", clients[1].Name)
+	assert.Equal(t, "google-nest-mini", clients[1].DnsName)
+
+	assert.Equal(t, "win10-vm", clients[2].Name)
+	assert.Equal(t, "win10-vm", clients[2].DnsName)
+	assert.Equal(t, 1, len(clients[2].IPV6List))
+	assert.Equal(t, "ffff::ffff:ffff:ffff:ffff", clients[2].IPV6List[0])
 }


### PR DESCRIPTION
This PR adds support for the properties I have observed being reported, I did not add `multilink` as I don't know what the data type is for that (all my wireless devices show an empty array).

I only needed `guest` but figured I may as well add them all.