### PR TITLE
Refresh login if token has expired/is not valid

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -20,6 +20,8 @@ type Controller struct {
 	token        string
 	siteId       string
 	Sites        map[string]string
+	user         string
+	pass         string
 }
 
 type ControllerInfo struct {
@@ -188,4 +190,12 @@ func (c *Controller) Login(user string, pass string) error {
 
 	return nil
 
+}
+
+func (c *Controller) refreshLogin() error {
+	err := c.Login(c.user, c.pass)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/controller.go
+++ b/controller.go
@@ -95,6 +95,9 @@ func New(baseURL string) Controller {
 		Jar:       jar,
 		Timeout:   (30 * time.Second),
 		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	return Controller{
@@ -140,6 +143,9 @@ func (c *Controller) GetControllerInfo() error {
 }
 
 func (c *Controller) Login(user string, pass string) error {
+
+	c.user = user
+	c.pass = pass
 
 	endpoint, err := url.JoinPath(c.baseURL, c.controllerId, "/api/v2/login")
 	if err != nil {
@@ -193,6 +199,8 @@ func (c *Controller) Login(user string, pass string) error {
 }
 
 func (c *Controller) refreshLogin() error {
+	jar, _ := cookiejar.New(nil)
+	c.httpClient.Jar = jar
 	err := c.Login(c.user, c.pass)
 	if err != nil {
 		return err

--- a/request.go
+++ b/request.go
@@ -35,6 +35,10 @@ func (c *Controller) invokeRequest(path string, queryParams map[string]string) (
 		return nil, err
 	}
 
+	if res.StatusCode == http.StatusFound {
+		fmt.Println("there is a login issue")
+	}
+
 	if res.StatusCode != http.StatusOK {
 		err = fmt.Errorf("status code: %d", res.StatusCode)
 		return nil, err

--- a/request.go
+++ b/request.go
@@ -30,6 +30,9 @@ func (c *Controller) invokeRequest(path string, queryParams map[string]string) (
 	req.Header.Set("Accept", "application/json")
 	req.Header.Add("Csrf-Token", c.token)
 
+	fmt.Printf("token before: %s\n", c.token)
+	fmt.Printf("jar before: %v\n", c.httpClient.Jar)
+
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -43,6 +46,9 @@ func (c *Controller) invokeRequest(path string, queryParams map[string]string) (
 			return nil, err
 		}
 		req.Header.Set("Csrf-Token", c.token)
+		fmt.Printf("token after : %s\n", c.token)
+		fmt.Printf("jar after : %v\n", c.httpClient.Jar)
+
 		res2, err := c.httpClient.Do(req)
 		if err != nil {
 			return nil, err

--- a/request.go
+++ b/request.go
@@ -35,8 +35,17 @@ func (c *Controller) invokeRequest(path string, queryParams map[string]string) (
 		return nil, err
 	}
 
+	// if the response code is 302 then there might be a login issue
+	// attempt to refresh the login and retry the request
 	if res.StatusCode == http.StatusFound {
-		fmt.Println("there is a login issue")
+		err := c.refreshLogin()
+		if err != nil {
+			return nil, err
+		}
+		res, err = c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/request.go
+++ b/request.go
@@ -30,9 +30,6 @@ func (c *Controller) invokeRequest(path string, queryParams map[string]string) (
 	req.Header.Set("Accept", "application/json")
 	req.Header.Add("Csrf-Token", c.token)
 
-	fmt.Printf("token before: %s\n", c.token)
-	fmt.Printf("jar before: %v\n", c.httpClient.Jar)
-
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -45,19 +42,18 @@ func (c *Controller) invokeRequest(path string, queryParams map[string]string) (
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Csrf-Token", c.token)
-		fmt.Printf("token after : %s\n", c.token)
-		fmt.Printf("jar after : %v\n", c.httpClient.Jar)
 
-		res2, err := c.httpClient.Do(req)
+		req, err := http.NewRequest("GET", omadaUrl.String(), nil)
 		if err != nil {
 			return nil, err
 		}
-		if res2.StatusCode != http.StatusOK {
-			err = fmt.Errorf("status code: %d", res.StatusCode)
+		req.Header.Set("Accept", "application/json")
+		req.Header.Add("Csrf-Token", c.token)
+		res, err = c.httpClient.Do(req)
+		if err != nil {
 			return nil, err
 		}
-		return res2, nil
+
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/request.go
+++ b/request.go
@@ -42,10 +42,16 @@ func (c *Controller) invokeRequest(path string, queryParams map[string]string) (
 		if err != nil {
 			return nil, err
 		}
-		res, err = c.httpClient.Do(req)
+		req.Header.Set("Csrf-Token", c.token)
+		res2, err := c.httpClient.Do(req)
 		if err != nil {
 			return nil, err
 		}
+		if res2.StatusCode != http.StatusOK {
+			err = fmt.Errorf("status code: %d", res.StatusCode)
+			return nil, err
+		}
+		return res2, nil
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/request.go
+++ b/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 )
 
 func (c *Controller) invokeRequest(path string, queryParams map[string]string) (*http.Response, error) {
@@ -29,15 +30,21 @@ func (c *Controller) invokeRequest(path string, queryParams map[string]string) (
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Add("Csrf-Token", c.token)
-
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	// if the response code is 302 then there might be a login issue
+	// if the response is a 302 to /login then there is a login issue
 	// attempt to refresh the login and retry the request
 	if res.StatusCode == http.StatusFound {
+
+		location := res.Header.Get("Location")
+		pattern, _ := regexp.Compile(`\/login$`)
+		if !pattern.MatchString(location) {
+			return nil, fmt.Errorf("unexpected response: redirect to %s", location)
+		}
+
 		err := c.refreshLogin()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Previously if the controller was updated/restarted/etc the existing login token would become invalid and there wasn't a simple way to detect this scenario. This change detects login failures when sending requests and will attempt to refresh the login before retrying the request.