### PR TITLE
IPv6 support and network test

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -25,9 +25,11 @@ func TestGetClients(t *testing.T) {
 
 	assert.Equal(t, "Google Nest Mini", clients[1].Name)
 	assert.Equal(t, "google-nest-mini", clients[1].DnsName)
+	assert.Equal(t, 1, len(clients[1].IPV6List))
+	assert.Equal(t, "2001:db8:f7::103", clients[1].IPV6List[0])
 
 	assert.Equal(t, "win10-vm", clients[2].Name)
 	assert.Equal(t, "win10-vm", clients[2].DnsName)
 	assert.Equal(t, 1, len(clients[2].IPV6List))
-	assert.Equal(t, "ffff::ffff:ffff:ffff:ffff", clients[2].IPV6List[0])
+	assert.Equal(t, "2001:db8:f7::102", clients[2].IPV6List[0])
 }

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,3 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/go.sum
+++ b/go.sum
@@ -7,3 +7,4 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/networks.go
+++ b/networks.go
@@ -4,25 +4,49 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 )
 
 type GetNetworksResponse struct {
 	ErrorCode int    `json:"errorCode"`
 	Msg       string `json:"msg"`
 	Result    struct {
-		TotalRows   int            `json:"totalRows"`
-		CurrentPage int            `json:"currentPage"`
-		CurrentSize int            `json:"currentSize"`
-		Data        []OmadaNetwork `json:"data"`
+		TotalRows   int                  `json:"totalRows"`
+		CurrentPage int                  `json:"currentPage"`
+		CurrentSize int                  `json:"currentSize"`
+		Data        []OmadaNetworkHelper `json:"data"`
 	} `json:"result"`
 }
 
 type OmadaNetwork struct {
-	Id      string `json:"id"`
-	Name    string `json:"name,omitempty"`
-	Domain  string `json:"domain,omitempty"`
-	Purpose string `json:"purpose"`
-	Subnet  string `json:"gatewaySubnet"`
+	Id         string `json:"id"`
+	Name       string `json:"name,omitempty"`
+	Domain     string `json:"domain,omitempty"`
+	Purpose    string `json:"purpose"`
+	Subnet     string `json:"gatewaySubnet"`
+	Ipv6Subnet string
+}
+
+type OmadaNetworkHelper struct {
+	Id                   string `json:"id"`
+	Name                 string `json:"name,omitempty"`
+	Domain               string `json:"domain,omitempty"`
+	Purpose              string `json:"purpose"`
+	Subnet               string `json:"gatewaySubnet"`
+	LanNetworkIpv6Config struct {
+		Proto  string `json:"proto"`
+		Enable int    `json:"enable"`
+		Slaac  struct {
+			Prefix string `json:"prefix"`
+		} `json:"slaac"`
+		Rdnss struct {
+			Prefix string `json:"prefix"`
+		} `json:"rdnss"`
+		Dhcpv6 struct {
+			Gateway string `json:"gateway"`
+			Subnet  int    `json:"subnet"`
+		} `json:"dhcpv6"`
+	} `json:"lanNetworkIpv6Config"`
 }
 
 func (c *Controller) GetNetworks() ([]OmadaNetwork, error) {
@@ -36,6 +60,7 @@ func (c *Controller) GetNetworks() ([]OmadaNetwork, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	var networkResponse GetNetworksResponse
 	if err := json.NewDecoder(res.Body).Decode(&networkResponse); err != nil {
@@ -47,11 +72,49 @@ func (c *Controller) GetNetworks() ([]OmadaNetwork, error) {
 		return nil, err
 	}
 
-	networks := networkResponse.Result.Data
+	networkhelpers := networkResponse.Result.Data
+
+	networks := ConvertHelpersToNetworks(networkhelpers)
+
 	sort.Slice(networks, func(i, j int) bool {
 		return networks[i].Name < networks[j].Name
 	})
 
 	return networks, nil
+
+}
+
+func ConvertHelpersToNetworks(networkHelpers []OmadaNetworkHelper) []OmadaNetwork {
+
+	networks := make([]OmadaNetwork, 0, len(networkHelpers))
+
+	for _, networkHelper := range networkHelpers {
+		var network OmadaNetwork
+
+		network.Id = networkHelper.Id
+		network.Name = networkHelper.Name
+		network.Domain = networkHelper.Domain
+		network.Purpose = networkHelper.Purpose
+		network.Subnet = networkHelper.Subnet
+
+		if networkHelper.LanNetworkIpv6Config.Enable != 0 {
+			switch networkHelper.LanNetworkIpv6Config.Proto {
+			case "slaac":
+				network.Ipv6Subnet = networkHelper.LanNetworkIpv6Config.Slaac.Prefix + "/64"
+			case "rdnss":
+				network.Ipv6Subnet = networkHelper.LanNetworkIpv6Config.Rdnss.Prefix + "/64"
+			case "dhcpv6":
+				network.Ipv6Subnet =
+					networkHelper.LanNetworkIpv6Config.Dhcpv6.Gateway +
+						"/" +
+						strconv.Itoa(networkHelper.LanNetworkIpv6Config.Dhcpv6.Subnet)
+			}
+		}
+
+		networks = append(networks, network)
+
+	}
+
+	return networks
 
 }

--- a/networks_test.go
+++ b/networks_test.go
@@ -1,0 +1,58 @@
+package omada
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworks(t *testing.T) {
+
+	networks, err := testController.GetNetworks()
+	if err != nil {
+		t.Fatalf("test failure on 'GetNetworks': %v", err)
+	}
+
+	for _, network := range networks {
+		slog.Debug("Id:         " + network.Id)
+		slog.Debug("Name:       " + network.Name)
+		slog.Debug("Domain:     " + network.Domain)
+		slog.Debug("Purpose:    " + network.Purpose)
+		slog.Debug("Subnet:     " + network.Subnet)
+		slog.Debug("Ipv6Subnet: " + network.Ipv6Subnet)
+
+	}
+
+	expectedCount := 4
+	assert.Len(t, networks, expectedCount)
+
+	assert.Equal(t, "5efee9f40e4a4b066b212f89", networks[0].Id)
+	assert.Equal(t, "Default", networks[0].Name)
+	assert.Equal(t, "omada.home", networks[0].Domain)
+	assert.Equal(t, "interface", networks[0].Purpose)
+	assert.Equal(t, "10.0.0.1/24", networks[0].Subnet)
+	assert.Equal(t, "2001:db8:f7::/64", networks[0].Ipv6Subnet)
+
+	assert.Equal(t, "65bee8cd86967408e454daac", networks[1].Id)
+	assert.Equal(t, "Guest", networks[1].Name)
+	assert.Equal(t, "", networks[1].Domain)
+	assert.Equal(t, "interface", networks[1].Purpose)
+	assert.Equal(t, "10.0.200.1/24", networks[1].Subnet)
+	assert.Equal(t, "", networks[1].Ipv6Subnet)
+
+	assert.Equal(t, "66b13848e2f8c96db92bca15", networks[2].Id)
+	assert.Equal(t, "Test", networks[2].Name)
+	assert.Equal(t, "", networks[2].Domain)
+	assert.Equal(t, "vlan", networks[2].Purpose)
+	assert.Equal(t, "", networks[2].Subnet)
+	assert.Equal(t, "", networks[2].Ipv6Subnet)
+
+	assert.Equal(t, "62238f02dd3c1a436c3e0a64", networks[3].Id)
+	assert.Equal(t, "Work", networks[3].Name)
+	assert.Equal(t, "omada.work", networks[3].Domain)
+	assert.Equal(t, "interface", networks[3].Purpose)
+	assert.Equal(t, "10.0.100.1/24", networks[3].Subnet)
+	assert.Equal(t, "", networks[3].Ipv6Subnet)
+
+}

--- a/test-data/clients-response.json
+++ b/test-data/clients-response.json
@@ -42,7 +42,7 @@
                 "deviceType": "unknown",
                 "ip": "10.0.0.102",
                 "ipv6List": [
-                    "ffff::ffff:ffff:ffff:ffff"
+                    "2001:db8:f7::102"
                 ],
                 "connectType": 2,
                 "connectDevType": "switch",
@@ -73,6 +73,9 @@
                 "hostName": "Google-Nest-Mini",
                 "deviceType": "unknown",
                 "ip": "10.0.0.103",
+                "ipv6List": [
+                    "2001:db8:f7::103"
+                ],
                 "connectType": 1,
                 "connectDevType": "ap",
                 "connectedToWirelessRouter": false,

--- a/test-data/networks-response.json
+++ b/test-data/networks-response.json
@@ -1,0 +1,214 @@
+{
+    "errorCode": 0,
+    "msg": "Success.",
+    "result": {
+        "totalRows": 4,
+        "currentPage": 1,
+        "currentSize": 10,
+        "data": [
+            {
+                "id": "5efee9f40e4a4b066b212f89",
+                "site": "Default",
+                "name": "Default",
+                "purpose": "interface",
+                "interfaceIds": [
+                    "3_ebbc880352e440a2a6a67e9db4a35cd0",
+                    "4_368e1eaf2ed44c24ae36874cba3bf652",
+                    "5_443ca53bf9294ed489a1db93535bbcc9",
+                    "6_0535627bfbc143bdaec7e2c941355b73"
+                ],
+                "vlanType": 0,
+                "application": 0,
+                "vlan": 1,
+                "gatewaySubnet": "10.0.0.1/24",
+                "dhcpSettings": {
+                    "enable": true,
+                    "ipaddrStart": "10.0.0.100",
+                    "ipaddrEnd": "10.0.0.199",
+                    "ipRangePool": [
+                        {
+                            "ipaddrStart": "10.0.0.100",
+                            "ipaddrEnd": "10.0.0.199"
+                        }
+                    ],
+                    "ipRangeStart": 167772160,
+                    "ipRangeEnd": 167772415,
+                    "dhcpns": "manual",
+                    "priDns": "8.8.8.8",
+                    "sndDns": "8.8.4.4",
+                    "leasetime": 120,
+                    "options": []
+                },
+                "domain": "omada.home",
+                "igmpSnoopEnable": false,
+                "fastLeaveEnable": false,
+                "mldSnoopEnable": false,
+                "dhcpv6Guard": {
+                    "enable": false
+                },
+                "dhcpL2RelayEnable": false,
+                "dhcpGuard": {
+                    "enable": false
+                },
+                "portal": false,
+                "accessControlRule": true,
+                "rateLimit": false,
+                "lanNetworkIpv6Config": {
+                    "proto": "slaac",
+                    "enable": 1,
+                    "slaac": {
+                        "preType": 0,
+                        "prefix": "2001:db8:f7::",
+                        "dnsv6": "auto"
+                    }
+                },
+                "allLan": false,
+                "origName": "Default",
+                "interface": true,
+                "primary": true
+            },
+            {
+                "id": "65bee8cd86967408e454daac",
+                "site": "Default",
+                "name": "Guest",
+                "purpose": "interface",
+                "interfaceIds": [
+                    "3_ebbc880352e440a2a6a67e9db4a35cd0",
+                    "4_368e1eaf2ed44c24ae36874cba3bf652",
+                    "5_443ca53bf9294ed489a1db93535bbcc9",
+                    "6_0535627bfbc143bdaec7e2c941355b73"
+                ],
+                "vlanType": 0,
+                "application": 0,
+                "vlan": 200,
+                "gatewaySubnet": "10.0.200.1/24",
+                "dhcpSettings": {
+                    "enable": true,
+                    "ipaddrStart": "10.0.200.1",
+                    "ipaddrEnd": "10.0.200.254",
+                    "ipRangePool": [
+                        {
+                            "ipaddrStart": "10.0.200.1",
+                            "ipaddrEnd": "10.0.200.254"
+                        }
+                    ],
+                    "ipRangeStart": 167823360,
+                    "ipRangeEnd": 167823615,
+                    "dhcpns": "auto",
+                    "leasetime": 120
+                },
+                "igmpSnoopEnable": false,
+                "fastLeaveEnable": false,
+                "mldSnoopEnable": false,
+                "dhcpv6Guard": {
+                    "enable": false
+                },
+                "dhcpL2RelayEnable": false,
+                "dhcpGuard": {
+                    "enable": false
+                },
+                "portal": false,
+                "accessControlRule": false,
+                "rateLimit": false,
+                "lanNetworkIpv6Config": {
+                    "enable": 0
+                },
+                "allLan": false,
+                "origName": "Guest",
+                "interface": true,
+                "primary": false
+            },
+            {
+                "id": "66b13848e2f8c96db92bca15",
+                "site": "Default",
+                "name": "Test",
+                "purpose": "vlan",
+                "interfaceIds": [
+                    "3_ebbc880352e440a2a6a67e9db4a35cd0",
+                    "4_368e1eaf2ed44c24ae36874cba3bf652",
+                    "5_443ca53bf9294ed489a1db93535bbcc9",
+                    "6_0535627bfbc143bdaec7e2c941355b73"
+                ],
+                "application": 0,
+                "vlan": 99,
+                "igmpSnoopEnable": false,
+                "fastLeaveEnable": false,
+                "mldSnoopEnable": false,
+                "dhcpv6Guard": {
+                    "enable": false
+                },
+                "dhcpL2RelayEnable": false,
+                "dhcpGuard": {
+                    "enable": false
+                },
+                "portal": false,
+                "accessControlRule": false,
+                "rateLimit": false,
+                "allLan": false,
+                "origName": "Test",
+                "interface": false,
+                "primary": false
+            },
+            {
+                "id": "62238f02dd3c1a436c3e0a64",
+                "site": "Default",
+                "name": "Work",
+                "purpose": "interface",
+                "interfaceIds": [
+                    "4_368e1eaf2ed44c24ae36874cba3bf652",
+                    "5_443ca53bf9294ed489a1db93535bbcc9",
+                    "6_0535627bfbc143bdaec7e2c941355b73"
+                ],
+                "vlanType": 0,
+                "application": 0,
+                "vlan": 100,
+                "gatewaySubnet": "10.0.100.1/24",
+                "dhcpSettings": {
+                    "enable": true,
+                    "ipaddrStart": "10.0.100.1",
+                    "ipaddrEnd": "10.0.100.254",
+                    "ipRangePool": [
+                        {
+                            "ipaddrStart": "10.0.100.1",
+                            "ipaddrEnd": "10.0.100.254"
+                        }
+                    ],
+                    "ipRangeStart": 167797760,
+                    "ipRangeEnd": 167798015,
+                    "dhcpns": "manual",
+                    "priDns": "8.8.8.8",
+                    "sndDns": "8.8.4.4",
+                    "leasetime": 120,
+                    "options": []
+                },
+                "domain": "omada.work",
+                "igmpSnoopEnable": false,
+                "fastLeaveEnable": false,
+                "mldSnoopEnable": false,
+                "dhcpv6Guard": {
+                    "enable": false
+                },
+                "dhcpL2RelayEnable": false,
+                "dhcpGuard": {
+                    "enable": false
+                },
+                "portal": false,
+                "accessControlRule": false,
+                "rateLimit": false,
+                "lanNetworkIpv6Config": {
+                    "enable": 0
+                },
+                "allLan": false,
+                "origName": "Work",
+                "interface": true,
+                "primary": false
+            }
+        ],
+        "supportMultiVlan": true,
+        "supportRA": true,
+        "supportCustomDhcpOption": true,
+        "combinedGateway": false,
+        "dhcpRangePoolSize": 1,
+        "interfaceNum": 128
+    }
+}


### PR DESCRIPTION
I wanted to add IPv6 support to coredns_omada and saw that IPv6 support was missing here as well.

Changes:
- added IPv6 support to networks.go
  - introduced an OmadaNetworkHelper to properly read the JSON properties and write the IPv6 prefix to the OmadaNetwork type later
  - supports reading the prefix from slaac, dhcpv6 and rdnss configured subnets
  - I didn't test that for automatically assigned prefixes yet. I still have to test if it works if the gateway uses a prefix ID it adds to the prefix that was assigned by the provider or another router.
  - added the ConvertHelpersToNetworks function to convert the helper networks to OmadaNetwork type networks
- added test cases for networks
- added test cases for IPv6 clients and IPv6 networks