### PR TITLE
fix GetClients for Omada Controller >= 6.2.0

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,7 +3,20 @@ package omada
 import (
 	"fmt"
 	"sort"
+
+	goversion "github.com/hashicorp/go-version"
 )
+
+type clientsOpenAPIBody struct {
+	Filters struct {
+		Active bool `json:"active"`
+	} `json:"filters"`
+	Sorts                 struct{} `json:"sorts"`
+	HideHealthUnsupported bool     `json:"hideHealthUnsupported"`
+	Scope                 int      `json:"scope"`
+	Page                  int      `json:"page"`
+	PageSize              int      `json:"pageSize"`
+}
 
 type clientResponse struct {
 	ErrorCode int    `json:"errorCode"`
@@ -67,20 +80,22 @@ type Client struct {
 
 func (c *Controller) GetClients() ([]Client, error) {
 
-	path := fmt.Sprintf("api/v2/sites/%s/clients", c.siteId)
-	queryParams := map[string]string{
-		"currentPage":     "1",
-		"currentPageSize": "999",
-		"filters.active":  "true",
+	var res *clientResponse
+	var err error
+
+	minVer, _ := goversion.NewVersion("6.2.0")
+	curVer, _ := goversion.NewVersion(c.controllerVer)
+	if curVer != nil && curVer.GreaterThanOrEqual(minVer) {
+		res, err = c.getClientsOpenAPI()
+	} else {
+		res, err = c.getClientsLegacy()
 	}
-	res, err := invokeRequest[clientResponse](c, path, queryParams)
 	if err != nil {
 		return nil, err
 	}
 
 	if res.ErrorCode != 0 {
-		err = fmt.Errorf("failed to get list of clients: code='%d', message='%s'", res.ErrorCode, res.Msg)
-		return nil, err
+		return nil, fmt.Errorf("failed to get list of clients: code='%d', message='%s'", res.ErrorCode, res.Msg)
 	}
 
 	var clients []Client
@@ -98,4 +113,29 @@ func (c *Controller) GetClients() ([]Client, error) {
 
 	return clients, nil
 
+}
+
+func (c *Controller) getClientsLegacy() (*clientResponse, error) {
+	path := fmt.Sprintf("api/v2/sites/%s/clients", c.siteId)
+	queryParams := map[string]string{
+		"currentPage":     "1",
+		"currentPageSize": "999",
+		"filters.active":  "true",
+	}
+	return invokeRequest[clientResponse](c, path, queryParams)
+}
+
+func (c *Controller) getClientsOpenAPI() (*clientResponse, error) {
+	path := fmt.Sprintf("openapi/v2/%s/sites/%s/clients", c.controllerId, c.siteId)
+	body := clientsOpenAPIBody{
+		HideHealthUnsupported: true,
+		Scope:                 1,
+		Page:                  1,
+		PageSize:              999,
+	}
+	body.Filters.Active = true
+	extraHeaders := map[string]string{
+		"Omada-Request-Source": "web-local",
+	}
+	return invokePostRequest[clientResponse](c, path, body, extraHeaders)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetClientsOpenAPI(t *testing.T) {
+	server, c := setupOpenAPITestServer(t)
+	defer server.Close()
+
+	clients, err := c.GetClients()
+	if err != nil {
+		t.Fatalf("test failure on 'GetClients' (OpenAPI): %v", err)
+	}
+
+	assert.Len(t, clients, 3)
+	assert.Equal(t, "Client 001", clients[0].Name)
+	assert.Equal(t, "client-001", clients[0].DnsName)
+	ip := net.ParseIP(clients[0].Ip)
+	assert.NotNil(t, ip)
+}
+
 func TestGetClients(t *testing.T) {
 
 	clients, err := testController.GetClients()

--- a/controller.go
+++ b/controller.go
@@ -14,14 +14,15 @@ import (
 )
 
 type Controller struct {
-	httpClient   *http.Client
-	baseURL      string
-	controllerId string
-	token        string
-	siteId       string
-	Sites        map[string]string
-	user         string
-	pass         string
+	httpClient    *http.Client
+	baseURL       string
+	controllerId  string
+	controllerVer string
+	token         string
+	siteId        string
+	Sites         map[string]string
+	user          string
+	pass          string
 }
 
 type ControllerInfo struct {
@@ -139,6 +140,7 @@ func (c *Controller) GetControllerInfo() error {
 	}
 
 	c.controllerId = infoResponse.Result.OmadacID
+	c.controllerVer = infoResponse.Result.ControllerVer
 	return nil
 
 }

--- a/controller_test.go
+++ b/controller_test.go
@@ -40,43 +40,76 @@ func TestMain(m *testing.M) {
 
 }
 
-func setupTestServer() *httptest.Server {
-
-	controllerId := testData["controllerId"]
-	siteId := testData["siteId"]
-	pathLogin := fmt.Sprintf("/%s/api/v2/login", controllerId)
-	pathUsers := fmt.Sprintf("/%s/api/v2/users/current", controllerId)
-	pathClients := fmt.Sprintf("/%s/api/v2/sites/%s/clients", controllerId, siteId)
-	pathDevices := fmt.Sprintf("/%s/api/v2/sites/%s/devices", controllerId, siteId)
-	pathNetworks := fmt.Sprintf("/%s/api/v2/sites/%s/setting/lan/networks", controllerId, siteId)
-	pathDhcp := fmt.Sprintf("/%s/api/v2/sites/%s/setting/service/dhcp", controllerId, siteId)
-
-	responses := map[string]string{
-		"/api/info":  "./test-data/info-response.json",
-		pathLogin:    "./test-data/login-response.json",
-		pathUsers:    "./test-data/users-response.json",
-		pathClients:  "./test-data/clients-response.json",
-		pathDevices:  "./test-data/devices-response.json",
-		pathNetworks: "./test-data/networks-response.json",
-		pathDhcp:     "./test-data/dhcp-reservation-response.json",
-	}
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		responseFile, ok := responses[r.URL.Path]
-		if !ok {
-			log.Fatalf("Unexpected request path on mock server: %s", r.URL.Path)
-		}
-		response, err := os.ReadFile(responseFile)
+func serveFile(file string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := os.ReadFile(file)
 		if err != nil {
 			log.Fatal(err)
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write(response)
-	}))
+		w.Write(data)
+	}
+}
 
-	return server
+func newTestServer(routes map[string]http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler, ok := routes[r.URL.Path]
+		if !ok {
+			log.Fatalf("unexpected request path on mock server: %s", r.URL.Path)
+		}
+		handler(w, r)
+	}))
+}
+
+func commonRoutes(infoFile string) map[string]http.HandlerFunc {
+	controllerId := testData["controllerId"]
+	return map[string]http.HandlerFunc{
+		"/api/info": serveFile(infoFile),
+		fmt.Sprintf("/%s/api/v2/login", controllerId):         serveFile("./test-data/login-response.json"),
+		fmt.Sprintf("/%s/api/v2/users/current", controllerId): serveFile("./test-data/users-response.json"),
+	}
+}
+
+func setupTestServer() *httptest.Server {
+	controllerId := testData["controllerId"]
+	siteId := testData["siteId"]
+
+	routes := commonRoutes("./test-data/info-response.json")
+	routes[fmt.Sprintf("/%s/api/v2/sites/%s/clients", controllerId, siteId)] = serveFile("./test-data/clients-response.json")
+	routes[fmt.Sprintf("/%s/api/v2/sites/%s/devices", controllerId, siteId)] = serveFile("./test-data/devices-response.json")
+	routes[fmt.Sprintf("/%s/api/v2/sites/%s/setting/lan/networks", controllerId, siteId)] = serveFile("./test-data/networks-response.json")
+	routes[fmt.Sprintf("/%s/api/v2/sites/%s/setting/service/dhcp", controllerId, siteId)] = serveFile("./test-data/dhcp-reservation-response.json")
+
+	return newTestServer(routes)
 }
 
 func TestLogin(t *testing.T) {
 	assert.Equal(t, testData["controllerId"], testController.controllerId)
+}
+
+func setupOpenAPITestServer(t *testing.T) (*httptest.Server, Controller) {
+	t.Helper()
+	controllerId := testData["controllerId"]
+	siteId := testData["siteId"]
+
+	routes := commonRoutes("./test-data/openapi/info-response.json")
+	routes[fmt.Sprintf("/openapi/v2/%s/sites/%s/clients", controllerId, siteId)] = func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "web-local", r.Header.Get("Omada-Request-Source"))
+		assert.NotEmpty(t, r.Header.Get("Csrf-Token"))
+		serveFile("./test-data/clients-response.json")(w, r)
+	}
+
+	server := newTestServer(routes)
+	c := New(server.URL)
+	if err := c.GetControllerInfo(); err != nil {
+		t.Fatal("GetControllerInfo:", err)
+	}
+	if err := c.Login("user", "pass"); err != nil {
+		t.Fatal("Login:", err)
+	}
+	if err := c.SetSite("Home"); err != nil {
+		t.Fatal("SetSite:", err)
+	}
+	return server, c
 }

--- a/example/main.go
+++ b/example/main.go
@@ -11,7 +11,10 @@ import (
 func main() {
 
 	// variables
-	controllerUrl := "https://10.0.0.10"
+	controllerUrl, present := os.LookupEnv("OMADA_URL")
+	if !present {
+		controllerUrl = "https://10.0.0.10"
+	}
 	user, present := os.LookupEnv("OMADA_USERNAME")
 	if !present {
 		log.Fatal("⛔ required environment variable not set: OMADA_USERNAME")

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,14 @@
 module github.com/dougbw/go-omada
 
-go 1.18
+go 1.25.0
+
+require (
+	github.com/hashicorp/go-version v1.9.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
+github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/request.go
+++ b/request.go
@@ -1,12 +1,47 @@
 package omada
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
 )
+
+var loginRedirectPattern = regexp.MustCompile(`/login$`)
+
+// doRequest executes the request built by buildReq. If the response is a 302
+// redirect to /login, it refreshes the session and retries once.
+func (c *Controller) doRequest(buildReq func() (*http.Request, error)) (*http.Response, error) {
+	req, err := buildReq()
+	if err != nil {
+		return nil, err
+	}
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusFound {
+		return res, nil
+	}
+
+	res.Body.Close()
+	location := res.Header.Get("Location")
+	if !loginRedirectPattern.MatchString(location) {
+		return nil, fmt.Errorf("unexpected response: redirect to %s", location)
+	}
+	if err := c.refreshLogin(); err != nil {
+		return nil, err
+	}
+
+	req, err = buildReq()
+	if err != nil {
+		return nil, err
+	}
+	return c.httpClient.Do(req)
+}
 
 func invokeRequest[T any](c *Controller, path string, queryParams map[string]string) (*T, error) {
 
@@ -25,50 +60,71 @@ func invokeRequest[T any](c *Controller, path string, queryParams map[string]str
 	}
 	omadaUrl.RawQuery = values.Encode()
 
-	req, err := http.NewRequest("GET", omadaUrl.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Add("Csrf-Token", c.token)
-	res, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	// if the response is a 302 to /login then there is a login issue
-	// attempt to refresh the login and retry the request
-	if res.StatusCode == http.StatusFound {
-
-		res.Body.Close()
-
-		location := res.Header.Get("Location")
-		pattern, _ := regexp.Compile(`\/login$`)
-		if !pattern.MatchString(location) {
-			return nil, fmt.Errorf("unexpected response: redirect to %s", location)
-		}
-
-		err := c.refreshLogin()
-		if err != nil {
-			return nil, err
-		}
-
+	buildReq := func() (*http.Request, error) {
 		req, err := http.NewRequest("GET", omadaUrl.String(), nil)
 		if err != nil {
 			return nil, err
 		}
 		req.Header.Set("Accept", "application/json")
 		req.Header.Add("Csrf-Token", c.token)
-		res, err = c.httpClient.Do(req)
-		if err != nil {
-			return nil, err
-		}
+		return req, nil
+	}
+
+	res, err := c.doRequest(buildReq)
+	if err != nil {
+		return nil, err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		err = fmt.Errorf("status code: %d", res.StatusCode)
+		return nil, fmt.Errorf("status code: %d", res.StatusCode)
+	}
+
+	var out T
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
 		return nil, err
+	}
+
+	return &out, nil
+
+}
+
+// invokePostRequest sends a POST to baseURL+path (controllerId is NOT prepended)
+// with the given body marshalled as JSON and any extra headers.
+func invokePostRequest[T any](c *Controller, path string, body any, extraHeaders map[string]string) (*T, error) {
+
+	address, err := url.JoinPath(c.baseURL, path)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	buildReq := func() (*http.Request, error) {
+		req, err := http.NewRequest("POST", address, bytes.NewBuffer(bodyJSON))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Add("Csrf-Token", c.token)
+		for k, v := range extraHeaders {
+			req.Header.Set(k, v)
+		}
+		return req, nil
+	}
+
+	res, err := c.doRequest(buildReq)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code: %d", res.StatusCode)
 	}
 
 	var out T

--- a/test-data/openapi/info-response.json
+++ b/test-data/openapi/info-response.json
@@ -1,0 +1,13 @@
+{
+    "errorCode": 0,
+    "msg": "Success.",
+    "result": {
+        "controllerVer": "6.2.0.17",
+        "apiVer": "3",
+        "configured": true,
+        "type": 10,
+        "supportApp": true,
+        "omadacId": "123bee230c77bbb45d9c8545d04d700a",
+        "registeredRoot": true
+    }
+}


### PR DESCRIPTION
Omada Controller 6.2.x removed the old clients endpoint and replaced it with a new OpenAPI v2 POST endpoint. This breaks `GetClients()` with a general error.

The fix detects the controller version after `GetControllerInfo()` and picks the right implementation:
- **< 6.2.0** existing GET endpoint, unchanged
- **>= 6.2.0** `POST /openapi/v2/{controllerId}/sites/{siteId}/clients` with the `Omada-Request-Source: web-local` header

Also took the opportunity to deduplicate the 302/login-retry logic that was copy-pasted between `invokeRequest` and `invokePostRequest`.

Verified against a live 6.2.0.17 instance returning 21 clients.

Fixes dougbw/coredns_omada#81